### PR TITLE
Use dms_from_ocn from oslo_aero_control

### DIFF
--- a/src/aero_model.F90
+++ b/src/aero_model.F90
@@ -581,7 +581,7 @@ contains
 
   !=============================================================================
   subroutine aero_model_emissions( state, cam_in )
-     use phys_control, only: dms_from_ocn
+     use oslo_aero_control, only: dms_from_ocn
 
     ! Arguments:
     type(physics_state), intent(in)    :: state   ! Physics state variables

--- a/src/oslo_aero_control.F90
+++ b/src/oslo_aero_control.F90
@@ -10,13 +10,17 @@ module oslo_aero_control
   use namelist_utils,    only: find_group_name
   use cam_logfile,       only: iulog
   use cam_abortutils,    only: endrun
-  use atm_import_export, only: dms_from_ocn
+  use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
 
   implicit none
   private
 
   public :: oslo_aero_ctl_readnl ! read namelist from file
   public :: oslo_aero_getopts    ! generic query method
+
+  ! Public module data
+  ! Take DMS from ocean?
+  logical, public, protected :: dms_from_ocn = .false.
 
   ! Private module data
   character(len=16), parameter :: unset_str = 'UNSET'
@@ -102,6 +106,9 @@ contains
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filename")
     call mpi_bcast(ocean_filepath, len(ocean_filepath), mpi_character, mstrid, mpicom, ierr)
     if (ierr /= mpi_success) call endrun(subname//" mpi_bcast: ocean_filepath")
+
+    ! Set this from the driver namelist (always read first)
+    dms_from_ocn = drv_dms_from_ocn
 
     ! Reset dms_source if ocean is sending dms to atm
     if (dms_from_ocn) then


### PR DESCRIPTION
Use oslo_aero_control instead of phys_control.
This should resolve the circular dependency issue (once the accompanying CAM PR is merged into your PR branch).